### PR TITLE
Updated integration Kong OIDC plugin

### DIFF
--- a/docker/okta-kong-oidc/Dockerfile
+++ b/docker/okta-kong-oidc/Dockerfile
@@ -1,10 +1,7 @@
-FROM centos:7
-MAINTAINER Micah Silverman, micah.silverman@okta.com
+FROM kong:0.11.2
+LABEL maintainer="micah.silverman@okta.com, andy.march@okta.com"
 
-ENV KONG_VERSION 0.11.1
-
-RUN yum install -y wget https://bintray.com/kong/kong-community-edition-rpm/download_file?file_path=dists%2Fkong-community-edition-$KONG_VERSION.el7.noarch.rpm
-RUN yum install -y git unzip && yum clean all
+RUN yum install -y git unzip openssl openssl-devel gcc lua-devel luarocks && yum clean all
 RUN luarocks install kong-oidc
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
@@ -14,4 +11,4 @@ EXPOSE 8000 8443 8001 8444
 
 STOPSIGNAL SIGTERM
 
-CMD ["/usr/local/openresty/nginx/sbin/nginx", "-c", "/usr/local/kong/nginx.conf", "-p", "/usr/local/kong/"]
+CMD ["kong", "docker-start"]

--- a/docker/okta-kong-oidc/docker-entrypoint.sh
+++ b/docker/okta-kong-oidc/docker-entrypoint.sh
@@ -1,15 +1,19 @@
 #!/bin/sh
 set -e
 
-# Disabling nginx daemon mode
-export KONG_NGINX_DAEMON="off"
+export KONG_NGINX_DAEMON=off
 
-# Setting default prefix (override any existing variable)
-export KONG_PREFIX="/usr/local/kong"
+if [[ "$1" == "kong" ]]; then
+  PREFIX=${KONG_PREFIX:=/usr/local/kong}
+  mkdir -p $PREFIX
 
-# Prepare Kong prefix
-if [ "$1" = "/usr/local/openresty/nginx/sbin/nginx" ]; then
-	kong prepare -p "/usr/local/kong"
+  if [[ "$2" == "docker-start" ]]; then
+    kong prepare -p $PREFIX
+
+    exec /usr/local/openresty/nginx/sbin/nginx \
+      -p $PREFIX \
+      -c nginx.conf
+  fi
 fi
 
 exec "$@"

--- a/src/main/java/com/okta/examples/originexample/config/RequestContextUser.java
+++ b/src/main/java/com/okta/examples/originexample/config/RequestContextUser.java
@@ -9,6 +9,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.xml.bind.DatatypeConverter;
 import java.io.IOException;
 
 public class RequestContextUser {
@@ -24,14 +25,14 @@ public class RequestContextUser {
 
         try {
             RequestAttributes reqAttr = RequestContextHolder.currentRequestAttributes();
-
             if (
                 reqAttr instanceof ServletRequestAttributes &&
                 (req = ((ServletRequestAttributes) reqAttr).getRequest()) != null &&
                 (userInfoHeader = req.getHeader(USER_HEADER)) != null
             ) {
-                log.debug("Found user info from {} header with value {}", USER_HEADER, userInfoHeader);
-                User user =  mapper.readValue(userInfoHeader, User.class);
+                log.debug("Found user info header {}", USER_HEADER);
+                User user =  mapper.readValue(DatatypeConverter.parseBase64Binary(userInfoHeader), User.class);
+                log.debug("Resolved user {}",user.getFullName());
                 req.setAttribute(User.class.getName(), user);
                 return user;
             }


### PR DESCRIPTION
The Kong OIDC plugin now sends x-userinfo as a base64 string which broke this example. Have updated the header parsing.

Have updated the okta-kong-oidc image to base from Kong rather than installing it and to include Lua this address the issue seen in #2.  