### PR TITLE
Fix rpm source link / Update to check command exit status

### DIFF
--- a/docker/okta-kong-oidc/Dockerfile
+++ b/docker/okta-kong-oidc/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER Micah Silverman, micah.silverman@okta.com
 
 ENV KONG_VERSION 0.11.1
 
-RUN yum install -y wget https://bintray.com/kong/kong-community-edition-rpm/download_file?file_path=dists%2Fkong-community-edition-$KONG_VERSION.el7.noarch.rpm
-RUN yum install -y git unzip && yum clean all
-RUN luarocks install kong-oidc
+RUN yum install -y wget https://bintray.com/kong/kong-community-edition-rpm/download_file?file_path=centos%2F7%2Fkong-community-edition-$KONG_VERSION.el7.noarch.rpm \
+    && yum install -y git unzip && yum clean all \
+    && luarocks install kong-oidc
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
Download link(https://bintray.com/kong/kong-community-edition-rpm/download_file?file_path=dists%2Fkong-community-edition-$KONG_VERSION.el7.noarch.rpm) is now invalid.

Because this, download would fail and
`/bin/sh: luarocks: command not found`
error occurred.

So I fixed download link and added checking command exit status too.
